### PR TITLE
ci: pinact でGitHub Actionsのバージョンを固定する

### DIFF
--- a/.github/pinact.yaml
+++ b/.github/pinact.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/main/json-schema/pinact.json
+version: 3
+
+files:
+  - pattern: ".github/workflows/*.yml"
+  - pattern: ".github/actions/*/action.yml"
+
+ignore_actions:
+  - name: VOICEVOX/.github/.github/workflows/shared.yml
+    ref: main
+  - name: voicevox/merge-gatekeeper
+    ref: main

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,7 +7,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: github/issue-labeler@v2.0
+    - uses: github/issue-labeler@3ae0e4623c1fda729347ae0d8f1c2e52302ef4c6 # v2.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler.yml

--- a/.github/workflows/merge_gatekeeper.yml
+++ b/.github/workflows/merge_gatekeeper.yml
@@ -20,7 +20,7 @@ jobs:
           required_score: 2
           score_rules: |
             @Hiroshiba: 2
-      - uses: upsidr/merge-gatekeeper@v1
+      - uses: upsidr/merge-gatekeeper@09af7a82c1666d0e64d2bd8c01797a0bcfd3bb5d # v1.2.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           self: merge_gatekeeper

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,19 @@ jobs:
   typos:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: typos
-        uses: crate-ci/typos@v1.12.12
+        uses: crate-ci/typos@47912c390ab44028f45fe2abc0bb5c6d97392bf8 # v1.12.12
+
+  pinact:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: pinact
+        uses: suzuki-shunsuke/pinact-action@28aeb220eb3252ad0d4422dd5d9368e925acbd8d # v1.3.0
+        with:
+          skip_push: "true"
+          min_age: "7"
 
   voicevox_shared_workflow:
     uses: VOICEVOX/.github/.github/workflows/shared.yml@main
@@ -42,10 +52,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.x"
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,6 @@ VOICEVOX 用のリソースファイル置き場
 typos
 ```
 
-## 利用規約のチェック
-
-```bash
-python scripts/validate_terms.py
-```
-
 ## GitHub Actions のバージョン固定
 
 [pinact](https://github.com/suzuki-shunsuke/pinact) を使って GitHub Actions のバージョンを full-length commit SHA に固定しています。
@@ -37,6 +31,12 @@ pinact run
 
 # バージョンを更新して固定する
 pinact run --update --min-age 7
+```
+
+## 利用規約のチェック
+
+```bash
+python scripts/validate_terms.py
 ```
 
 ## ライセンス

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ python scripts/validate_terms.py
 ## GitHub Actions のバージョン固定
 
 [pinact](https://github.com/suzuki-shunsuke/pinact) を使って GitHub Actions のバージョンを full-length commit SHA に固定しています。
-プルリクエストを送ると自動でテストされます。
 
 ```bash
 # バージョンを固定する

--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ typos
 python scripts/validate_terms.py
 ```
 
+## GitHub Actions のバージョン固定
+
+[pinact](https://github.com/suzuki-shunsuke/pinact) を使って GitHub Actions のバージョンを full-length commit SHA に固定しています。
+プルリクエストを送ると自動でテストされます。
+
+```bash
+# バージョンを固定する
+pinact run
+
+# バージョンを更新して固定する
+pinact run --update --min-age 7
+```
+
 ## ライセンス
 
 ### scripts ディレクトリのファイル


### PR DESCRIPTION
## 内容

pinact で GitHub Actions のバージョンを full-length commit SHA にピン留めする。

## 関連 Issue

ref VOICEVOX/voicevox_project#82