### PR TITLE
ci: 書き込みが必要な job に permissions: を明示する

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
     - uses: github/issue-labeler@3ae0e4623c1fda729347ae0d8f1c2e52302ef4c6 # v2.0
       with:


### PR DESCRIPTION
## 内容

`GITHUB_TOKEN` のデフォルト権限を read-only に切り替えるにあたり、書き込みが必要な job に `permissions:` を明示しました。

- `labeler.yml` の `triage` job: `github/issue-labeler` が Issue にラベルを付与するため `issues: write` を追加

`test.yml` の `voicevox_shared_workflow` job は reusable workflow 呼び出し側に `contents: read`、`packages: read`、`statuses: write` がすでに明示済みです。`merge_gatekeeper.yml` は `GITHUB_TOKEN` を読み取り用途で使っているため対応不要です。

## 関連 Issue

ref VOICEVOX/voicevox_project#93
